### PR TITLE
The initial Train/test/val and Label/unlabel split changed 

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python Debugger: hypothesis-testing",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "${workspaceFolder}\\main.py",
+            "args": ["--d", "dna", "--r", "123"],
+            "console": "integratedTerminal"
+        }
+    ]
+}

--- a/acquisitions/random.py
+++ b/acquisitions/random.py
@@ -5,6 +5,7 @@ class Random():
         self.pool = pool
     def query(self) -> int:
         all_unlabelled_indecies = self.pool.get_unlabeled_indecies()
+        print(f"current number of unlabeled data: {len(all_unlabelled_indecies)}")
         all_scores = np.random.random(len(all_unlabelled_indecies))
         max_scores = np.argwhere(np.isclose(all_scores, all_scores.max())).ravel()            
         self.pool.set_seed()

--- a/core/active_learning.py
+++ b/core/active_learning.py
@@ -11,6 +11,63 @@ class ActiveLearning:
         self.clf = core.Classifier(pool=self.pool)
 
     def run(self) -> None:
-        best_dropout_rate, best_l2_reg, best_val_loss = self.clf.tune()
-        test_loss, test_metrics = self.clf.test(best_l2_reg, best_dropout_rate)
-        print(test_loss)
+
+        iteration = []
+        test_loss_list = []
+        best_dropout_rate_list = []
+        best_l2_reg_list = []
+
+        for i in range(754):
+            print(f"============ iteration: {i+1} ============")
+            print(f"current number of labeled data: {len(self.pool.idx_label)}")
+            
+            best_dropout_rate, best_l2_reg, best_val_loss = self.clf.tune()
+            test_loss, test_metrics = self.clf.test(best_l2_reg, best_dropout_rate)
+            
+            iteration.append(i)
+            test_loss_list.append(test_loss)
+            best_dropout_rate_list.append(best_dropout_rate)  
+            best_l2_reg_list.append(best_l2_reg)
+
+            self.pool.add_labeled_data(self.acquisition_function.query())
+
+        print(f"============ Final Results ============")
+        
+        print(f"test loss: {test_loss_list}")
+        print(f"best dropout rate: {best_dropout_rate_list}")
+        print(f"best l2 reg: {best_l2_reg_list}")
+
+        import matplotlib.pyplot as plt
+
+        # Assuming test_loss_list is defined and accessible
+        iterations = range(len(test_loss_list))
+
+        plt.figure(figsize=(15, 5))
+
+        # Plot for test loss
+        plt.subplot(1, 3, 1)  # 1 row, 3 columns, 1st subplot
+        plt.plot(iterations, test_loss_list, label='Test Loss')
+        plt.xlabel('Iteration')
+        plt.ylabel('Test Loss')
+        plt.title('Test Loss per Iteration')
+        plt.legend()
+
+        # Plot for best dropout rate
+        plt.subplot(1, 3, 2)  # 1 row, 3 columns, 2nd subplot
+        plt.plot(iterations, best_dropout_rate_list, label='Best Dropout Rate', linestyle='--')
+        plt.xlabel('Iteration')
+        plt.ylabel('Dropout Rate')
+        plt.title('Dropout Rate per Iteration')
+        plt.legend()
+
+        # Plot for best l2 reg
+        plt.subplot(1, 3, 3)  # 1 row, 3 columns, 3rd subplot
+        plt.plot(iterations, best_l2_reg_list, label='Best L2 Reg', linestyle='-.')
+        plt.xlabel('Iteration')
+        plt.ylabel('L2 Regularization')
+        plt.title('L2 Regularization per Iteration')
+        plt.legend()
+
+        plt.tight_layout()
+        plt.show()
+            

--- a/core/pool.py
+++ b/core/pool.py
@@ -23,18 +23,31 @@ class Pool():
         # setting the indecies
         self.set_seed()
         self.idx_abs = np.arange(len(self.dataset)) # absolute indecies
-        # setting the labeled indecies
-        initial_lb_size = float(self.dataset_config['labeled_share']) * len(self.dataset) # initial labeled size
-        self.set_seed()
-        self.idx_label = np.random.choice(self.idx_abs, size=math.floor(initial_lb_size), replace=False) # original labeled indecies
+
         # static hold-out testing  
-        # setting the train, validation and test indecies
+        # 1 setting the train, validation and test indecies
         validation_ratio = float(self.dataset_config['val_share'])
         test_ratio = float(self.dataset_config['test_share'])
         self.set_seed()
-        self.idx_train, rest_data = train_test_split(self.idx_label, test_size=validation_ratio+test_ratio)
+        self.idx_train, rest_data = train_test_split(self.idx_abs, test_size=validation_ratio+test_ratio)
         self.set_seed()
         self.idx_test, self.idx_val = train_test_split(rest_data, test_size=validation_ratio/(test_ratio+validation_ratio))
+
+
+        # setting the labeled indecies
+        initial_lb_size = float(self.dataset_config['labeled_share']) * len(self.idx_train) # initial labeled size
+        self.set_seed()
+        self.idx_label = np.random.choice(self.idx_train, size=math.floor(initial_lb_size), replace=False) # original labeled indecies
+
+        self.get_unlabeled_indecies()
+
+        print(f"Dataset: {len(self.dataset)}")
+        print(f"Train: {len(self.idx_train)}")
+        print(f"Validation: {len(self.idx_val)}")
+        print(f"Test: {len(self.idx_test)}")
+        print(f"Initial labeled data: {len(self.idx_label)}")
+
+        
 
     def set_seed(self, seed: Optional[int] = None) -> None:
         if seed is None:
@@ -47,7 +60,7 @@ class Pool():
     
     def get_loaders(self) -> tuple:
         '''Returns the train, validation and test loaders respectively.'''
-        train_loader = DataLoader(Subset(self.dataset, self.idx_train), batch_size=int(self.dataset_config['batch_size']), shuffle=True)
+        train_loader = DataLoader(Subset(self.dataset, self.idx_label), batch_size=int(self.dataset_config['batch_size']), shuffle=True)
         val_loader = DataLoader(Subset(self.dataset, self.idx_val), batch_size=int(self.dataset_config['batch_size']), shuffle=False)
         test_loader = DataLoader(Subset(self.dataset, self.idx_test), batch_size=int(self.dataset_config['batch_size']), shuffle=False)
         return train_loader, val_loader, test_loader
@@ -55,15 +68,15 @@ class Pool():
     def get_test_loaders(self) -> tuple:
         '''Returns the train and test loaders respectively. train is consisted of the union train and validation sets.'''
         train_loader = DataLoader(Subset(self.dataset, np.concatenate((
-            self.idx_train, self.idx_val))), batch_size=int(self.dataset_config['batch_size']), shuffle=True)
+            self.idx_label, self.idx_val))), batch_size=int(self.dataset_config['batch_size']), shuffle=True)
         test_loader = DataLoader(Subset(self.dataset, self.idx_test), batch_size=int(self.dataset_config['batch_size']), shuffle=False)
         return train_loader, test_loader
     
     def add_labeled_data(self, idx: int) -> None:
         '''Add labeled data to the pool.'''
         self.idx_label = np.concatenate((self.idx_label, [idx]))
-        self.idx_train = np.concatenate((self.idx_train, [idx]))
+        #self.idx_train = np.concatenate((self.idx_train, [idx]))
 
     def get_unlabeled_indecies(self) -> np.ndarray:
         '''Returns the unlabeled data.'''
-        return np.setdiff1d(self.idx_abs, self.idx_label)
+        return np.setdiff1d(self.idx_train, self.idx_label)

--- a/params.ini
+++ b/params.ini
@@ -3,7 +3,7 @@
 
 [DNA]
 data = data/dna/dna.npz
-labeled_share = 0.33
+labeled_share = 0.0055
 test_share = 0.2
 val_share = 0.2
 n_features = 180


### PR DESCRIPTION
Before this, the implementation was based on what we discussed with Ilia, and the summary image that was created by @canelin6  based on that discussion.
But, based on Shera's experiments, we changed that.
It is now implemented as the baseline Munjal paper. 
To quote the paper:  

> Given a dataset D, we split it into train (Tr), validation (V ),
and test (Ts) sets. The train set is further divided into the
initial labeled (L0) and unlabeled (U0) sets.

Thanks to @shera-work for noticing this.